### PR TITLE
requirejs compatibility fix, returning function pointer.

### DIFF
--- a/lib/mediator.js
+++ b/lib/mediator.js
@@ -19,9 +19,12 @@
   if(typeof root.exports === 'function') {
     // Node/CommonJS
     root.exports.Mediator = factory();
-  } else if(typeof root.define === 'function' && root.define.amd) {
+  } else if(typeof define === 'function' && define.amd) {
     // AMD
-    root.define(factory());
+    define(function() {
+      root.Mediator = factory();
+      return root.Mediator();
+    });
   } else {
     // Browser global
     root.Mediator = factory();


### PR DESCRIPTION
Fixing the require.js part.  It was not working the way requirejs expects it to, which was causing problems when trying to optimize using r.js.

This change passes define a function pointer to an anonymous function now, which acts as the factory to return an instantiation of the Mediator object instead of the Mediator object as a function.  Tested with require.js and r.js.
