### PR TITLE
Fixed looping through subscriptions

### DIFF
--- a/lib/mediator.js
+++ b/lib/mediator.js
@@ -221,6 +221,8 @@
 
           if(subscriber.options.calls < 1){
             this.removeSubscriber(subscriber.id);
+            y--;
+            x--;
           }else{
             subscriber.update(subscriber.options);
           }


### PR DESCRIPTION
After removal of subscriber array index and length are decreased in order to loop through just existing array elements.
