### PR TITLE
Fixed typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "mocha",
     "test_with_coverage": "mocha && MEDIATOR_JS_COV=1 mocha -R html-cov > coverage.html"
   },
-  "respository": {
+  "repository": {
     "type": "git",
     "url": "git://github.com/ajacksified/Mediator.js.git"
   },


### PR DESCRIPTION
`respository` → `repository`

otherwise npm complains during package installation:

```
npm WARN package.json mediator-js@0.9.6 No repository field.
```
