### PR TITLE
Fix bug with removing subscribers w/ predicates

### DIFF
--- a/lib/mediator.js
+++ b/lib/mediator.js
@@ -208,20 +208,20 @@
 
         if(!this.stopped){
           subscriber = this._subscribers[x];
+          subsBefore = this._subscribers.length;
           if(subscriber.options !== undefined && typeof subscriber.options.predicate === "function"){
             if(subscriber.options.predicate.apply(subscriber.context, data)){
               subscriber.fn.apply(subscriber.context, data);
               called = true;
             }
           }else{
-            subsBefore = this._subscribers.length;
             subscriber.fn.apply(subscriber.context, data);
-            subsAfter = this._subscribers.length;
-            y = subsAfter;
-            if (subsAfter === subsBefore - 1){
-              x--;
-            }
             called = true;
+          }
+          subsAfter = this._subscribers.length;
+          y = subsAfter;
+          if (subsAfter === subsBefore - 1){
+            x--;
           }
         }
 

--- a/test/MediatorSpec.js
+++ b/test/MediatorSpec.js
@@ -167,6 +167,27 @@ describe("Mediator", function() {
       expect(spy).not.called;
     });
 
+    it("should allow subscriber to remove itself", function(){
+      var removerCalled = false;
+      var predicate = function(data){
+        return true;
+        };
+      var remover = function(){
+          removerCalled = true;
+          mediator.remove("test", sub.id);
+        };
+
+      var spy1 = sinon.spy();
+
+      var sub = mediator.subscribe("test", remover, {predicate: predicate});
+      mediator.subscribe("test", spy1);
+      mediator.publish("test");
+
+      expect(removerCalled).to.be.true;
+      expect(spy1).called;
+      expect(mediator.getChannel("test")._subscribers.length).to.equal(1);
+    });
+
     it("should remove subscribers for a given channel / named function pair", function(){
       var spy = sinon.spy(),
           spy2 = sinon.spy();


### PR DESCRIPTION
I've added a test case that currently fails with:

```
TypeError: Cannot read property 'options' of undefined
  at Object.Channel.publish (lib/mediator.js:211:24)
```

The issue is that the "subsAfter/subsBefore" logic to handle a subscriber removing itself is only happening when the subscriber doesn't have a predicate.

(seems there might also be another issue if a subscriber removes >1 subscriber, but I haven't tried to build a test case for that, one thing at a time..)
