### PR TITLE
Add read-only mode to getChannel

### DIFF
--- a/lib/mediator.js
+++ b/lib/mediator.js
@@ -276,7 +276,6 @@
 
           if(!channel.hasChannel(namespaceHierarchy[x])){
             if (readOnly) {
-              channel = null;
               break;
             } else {
               channel.addChannel(namespaceHierarchy[x]);
@@ -297,7 +296,7 @@
     // index.
 
     subscribe: function(channelName, fn, options, context){
-      var channel = this.getChannel(channelName, false);
+      var channel = this.getChannel(channelName || "", false);
 
       options = options || {};
       context = context || {};
@@ -323,7 +322,9 @@
 
     getSubscriber: function(identifier, channelName){
       var channel = this.getChannel(channelName || "", true);
-      if (channel == null) {
+      // We have to check if channel within the hierarchy exists and if it is
+      // an exact match for the requested channel
+      if (channel.namespace !== channelName) {
         return null;
       }
 
@@ -335,7 +336,7 @@
 
     remove: function(channelName, identifier){
       var channel = this.getChannel(channelName || "", true);
-      if (channel == null) {
+      if (channel.namespace !== channelName) {
         return false;
       }
 
@@ -349,7 +350,7 @@
 
     publish: function(channelName){
       var channel = this.getChannel(channelName || "", true);
-      if (channel == null) {
+      if (channel.namespace !== channelName) {
         return null;
       }
 

--- a/test/MediatorSpec.js
+++ b/test/MediatorSpec.js
@@ -115,7 +115,7 @@ describe("Mediator", function() {
       mediator.publish("test");
 
       expect(spy).called;
-      expect(spy).called;
+      expect(spy2).called;
     });
 
     it("should pass arguments to the given function", function(){
@@ -346,6 +346,20 @@ describe("Mediator", function() {
       expect(spy).not.called;
       expect(spy2).called;
     });
+
+    it("should publish to parents of non-existing namespaces", function(){
+      var spy = sinon.spy(),
+          spy2 = sinon.spy();
+
+      mediator.subscribe("test:test1:test2", spy);
+      mediator.subscribe("test", spy2);
+
+      mediator.publish("test:test1", "data");
+
+      expect(spy).not.called;
+      expect(spy2).called;
+    });
+
   });
 
   describe("aliases", function(){


### PR DESCRIPTION
getChannel() would always create every non-existing channel in a channel's
hierarchy. When setting up a subscription this is fine but when trying to
retrieve or publish this behaviour is unwanted.

In the following cases this could cause the creation of unnecessary or
even unwanted channels:
- getSubscriber(), if the channel doesn't exist there is no subscriber
  and no need to create the channel
- remove(), if the channel doesn't exist there is nothing to
  remove and no need to create the channel
- publish(), when trying to publish data to a channel there is no need
  to create the channel as there would be no subscribers

Any of these scenario's could happen when there is a typo in the channel
namespace.
