### PR TITLE
Change _channels type to object

### DIFF
--- a/lib/mediator.js
+++ b/lib/mediator.js
@@ -86,7 +86,7 @@
 
     this.namespace = namespace || "";
     this._subscribers = [];
-    this._channels = [];
+    this._channels = {};
     this._parent = parent;
     this.stopped = false;
   }


### PR DESCRIPTION
_channels was initiated as an array but is used as an object in the code.
While you can add your own properties to the array object it is not the
proper base type to use in this case.
