### PR TITLE
Change UMD definition

### DIFF
--- a/lib/mediator.js
+++ b/lib/mediator.js
@@ -16,15 +16,15 @@
 (function(global, factory) {
   'use strict';
 
-  if(typeof exports !== 'undefined') {
-    // Node/CommonJS
-    exports.Mediator = factory();
-  } else if(typeof define === 'function' && define.amd) {
+  if(typeof define === 'function' && define.amd) {
     // AMD
     define('mediator-js', [], function() {
       global.Mediator = factory();
       return global.Mediator;
     });
+  } else if (typeof exports !== 'undefined') {
+    // Node/CommonJS
+    exports.Mediator = factory();
   } else {
     // Browser global
     global.Mediator = factory();


### PR DESCRIPTION
According to the [UMD-JS Github project](https://github.com/umdjs/umd) it is
better to first check for AMD and then for CommonJS. The reason being that
some build tools expose an exports object which could lead to a fall positive
for CommonJS.
