### PR TITLE
Fix infinite mediator.once

### DIFF
--- a/lib/mediator.js
+++ b/lib/mediator.js
@@ -206,9 +206,9 @@
       for(x, y; x < y; x++) {
         // By default set the flag to false
         shouldCall = false;
+        subscriber = this._subscribers[x];
 
         if(!this.stopped){
-          subscriber = this._subscribers[x];
           subsBefore = this._subscribers.length;
           if(subscriber.options !== undefined && typeof subscriber.options.predicate === "function"){
             if(subscriber.options.predicate.apply(subscriber.context, data)){
@@ -218,12 +218,6 @@
           }else{
             // There is no predicate to match, the callback should always be called
             shouldCall = true;
-          }
-
-          subsAfter = this._subscribers.length;
-          y = subsAfter;
-          if (subsAfter === subsBefore - 1){
-            x--;
           }
         }
 
@@ -236,13 +230,17 @@
             // Once the number of calls left reaches zero or less we need to remove the subscriber
             if(subscriber.options.calls < 1){
               this.removeSubscriber(subscriber.id);
-              y--;
-              x--;
             }
           }
           // Now we call the callback, if this in turns publishes to the same channel it will no longer
           // cause the callback to be called as we just removed it as a subscriber
           subscriber.fn.apply(subscriber.context, data);
+
+          subsAfter = this._subscribers.length;
+          y = subsAfter;
+          if (subsAfter === subsBefore - 1){
+            x--;
+          }
         }
       }
 


### PR DESCRIPTION
This fixes issue #29 which outlines a situation where a callback method
would get called an infinite number of times if the callback publishes
to the same channel that caused the callback to be triggered in the
first place.

By first checking if the subscriber will be called and decreasing its
call counter by one we can remove the subscriber from the channel before
the callback method is called. This will prevent the infinite loop from
occurring.
