### PR TITLE
Add automatic cleanup of channels

### DIFF
--- a/lib/mediator.js
+++ b/lib/mediator.js
@@ -174,21 +174,68 @@
       return this._channels[channel];
     },
 
-    removeSubscriber: function(identifier){
+    autoCleanChannel: function() {
+      // First make sure there are no more subscribers, if there are we
+      // can stop processing the channel any further
+      if (this._subscribers.length !== 0) {
+        return;
+      }
+
+      // Next we need to make sure there are no more sub-channels that
+      // have this channel as its parent channel. We try to iterate over the
+      // properties of _channels and as soon as we find a property we've
+      // set we will stop processing the channel any further
+      for (var key in this._channels) {
+        if (this._channels.hasOwnProperty(key)) {
+          return;
+        }
+      }
+
+      // The last check before we can remove the channel is to see if it
+      // has a parent. If there is no parent we don't want to remove this
+      // channel
+      if (this._parent != null) {
+        // We need the ID by which this channel is known to its parent, it should
+        // be the last part of the namespace. We need split the namespace up and
+        // take its last element to pass along to the removeChannel method
+        var path = this.namespace.split(':'),
+            channelName = path[path.length - 1];
+        // The parent of the current channel to remove this channel
+        this._parent.removeChannel(channelName);
+      }
+    },
+
+    removeChannel: function(channelName) {
+      if (this.hasChannel(channelName)) {
+        this._channels[channelName] = null;
+        delete this._channels[channelName];
+        // After removing a sub-channel we can check if that makes this channel
+        // suitable for auto clean up
+        this.autoCleanChannel();
+      }
+    },
+
+    removeSubscriber: function(identifier, autoCleanup){
       var x = this._subscribers.length - 1;
+      // We want to make sure the default value for autoCleanup is false, this way
+      // the new behaviour is opt-in.
+      autoCleanup = (typeof autoCleanup === 'undefined') ? false : autoCleanup;
 
       // If we don't pass in an id, we're clearing all
       if(!identifier){
         this._subscribers = [];
-        return;
-      }
-
-      // Going backwards makes splicing a whole lot easier.
-      for(x; x >= 0; x--) {
-        if(this._subscribers[x].fn === identifier || this._subscribers[x].id === identifier){
-          this._subscribers[x].channel = null;
-          this._subscribers.splice(x,1);
+      } else {
+        // Going backwards makes splicing a whole lot easier.
+        for(x; x >= 0; x--) {
+          if(this._subscribers[x].fn === identifier || this._subscribers[x].id === identifier){
+            this._subscribers[x].channel = null;
+            this._subscribers.splice(x,1);
+          }
         }
+      }
+      // Check if we should attempt to automatically clean up the channel
+      if (autoCleanup) {
+        this.autoCleanChannel();
       }
     },
 
@@ -340,15 +387,17 @@
     },
 
     // Remove a subscriber from a given channel namespace recursively based on
-    // a passed-in subscriber id or named function.
+    // a passed-in subscriber id or named function. If autoClean is true it will
+    // attempt to automatically clean up the channel when it no longer has any
+    // subscribers and sub-channels
 
-    remove: function(channelName, identifier){
+    remove: function(channelName, identifier, autoClean){
       var channel = this.getChannel(channelName || "", true);
       if (channel.namespace !== channelName) {
         return false;
       }
 
-      channel.removeSubscriber(identifier);
+      channel.removeSubscriber(identifier, autoClean);
     },
 
     // Publishes arbitrary data to a given channel namespace. Channels are


### PR DESCRIPTION
Channels which no longer have any subscribers and no sub-channels are
just taking up resources without any purpose. These channels also add
unnecessary time when trying to publish to or getting a subscriber from
them.

This commit adds a new parameter `autoClean` to the `remove` method on
the Mediator class. When this parameter has the value `true` it will
check if the channel from which a subscriber is removed can automatically
be removed. By default the parameter will be false, making this new
behaviour of the Mediator opt-in rather than opt-out.

In order to qualify for automatic removal the channel needs to meet the
following three criteria:
1. The channel should not have any subscribers
2. The channel should not be the parent to any other channels
3. The channel should have a parent channel

Only when these three criteria are met will the channel request its
parent to be removed. This in turn will trigger the parent to check if
it meets the criteria for automatic removal.

Example

```
- root channel
  - channel 1: 2 subscribers
  - channel 2: 1 subscriber
    - channel 2.1: 1 subscriber
  - channel 3: no subscriber
    - channel 3.1: 1 subscriber
```

Removing a subscriber from channel 1 will NOT cause it to be removed as
the channel still has one more subscriber. Only when the second
subscriber is removed will channel 1 remove itself as it no longer has
any subscribers and no sub-channel.s

Removing a subscriber from channel 2 will NOT cause it to be removed.
While channel 2 will no longer have any subscribers it is still the
parent of channel 2.1 and thus doesn't meet the three criteria for auto
removal.

Removing the subscriber from channel 2.1 after having removed the
subscriber from channel 2 will cause channel 2.1 to be automatically
removed as it doesn't have other subscriber and it isn't the parent to
any other channels. Once channel 2.1 is removed it will in turn cause
channel 2 to remove itself as it is now no longer a parent to any
channels and thus meets the three criteria for auto removal.

Removing a subscriber from channel 3.1 will cause both channel 3.1 and
channel 3 to removed. Neither has any subscribers left and once channel
3.1 tells channel 3 to remove it from its channels it causes channel 3
to no longer be the parent to any channels.

Unit tests for these scenarios have been added to ChannelSpec.
