### PR TITLE
Update README.md for more clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,12 @@ Subscription signature:
     mediator.publish(channel, <data, data, ... >)
     mediator.remove(channel, <identifier>)
 
-Additionally, `on` and `bind` are aliased to `subscribe`, and `trigger` and
-`emit` are bound to `publish`. `off` is an alias for `remove`. You can use
-`once` to subscribe to an event that should only be fired once.
+Additionally,
+
+* `subscribe`: is alias for `on` and `bind`
+* `publish`: is alias for `trigger` and `emit` 
+* `off`: is an alias for `remove`
+* `once`: can be used to subscribe to an event that should only be fired once.
 
 Subscriber signature:
 


### PR DESCRIPTION
Add bulletted list to eliminate the super confusing listing of aliases in one sentence. (it took more than one pass to fully understand that there is one alias for more than one function name).